### PR TITLE
Fix imageColorTint

### DIFF
--- a/raylib/rcore_wasm.go
+++ b/raylib/rcore_wasm.go
@@ -267,7 +267,6 @@ var imageMipmaps = wasm.Proc("ImageMipmaps")
 var imageDither = wasm.Proc("ImageDither")
 var imageRotateCW = wasm.Proc("ImageRotateCW")
 var imageRotateCCW = wasm.Proc("ImageRotateCCW")
-var imageColorTint = wasm.Proc("ImageColorTint")
 var imageColorInvert = wasm.Proc("ImageColorInvert")
 var imageColorGrayscale = wasm.Proc("ImageColorGrayscale")
 var imageColorContrast = wasm.Proc("ImageColorContrast")
@@ -2427,10 +2426,16 @@ func ImageRotateCCW(image *Image) {
 	wasm.Free(fl...)
 }
 
+//go:wasmimport raylib _ImageColorTint
+func imageColorTint(imgStruct wasmrt.Ptr, color wasmrt.Ptr)
+
 // ImageColorTint - Modify image color: tint
 func ImageColorTint(image *Image, col color.RGBA) {
-	_, fl := imageColorTint.Call(image, wasm.Struct(col))
-	wasm.Free(fl...)
+	cImage, free := wasmrt.CopyValueToC(image)
+	ccol, free := wasmrt.CopyValueToC(&col)
+	defer free()
+	imageColorTint(cImage, ccol)
+	wasmrt.CopyValueToGo(cImage, image)
 }
 
 // ImageColorInvert - Modify image color: invert

--- a/raylib/rcore_wasm.go
+++ b/raylib/rcore_wasm.go
@@ -2431,11 +2431,11 @@ func imageColorTint(imgStruct wasmrt.Ptr, color wasmrt.Ptr)
 
 // ImageColorTint - Modify image color: tint
 func ImageColorTint(image *Image, col color.RGBA) {
-	cImage, free := wasmrt.CopyValueToC(image)
-	defer free()
-	ccol, free := wasmrt.CopyValueToC(&col)
-	defer free()
-	imageColorTint(cImage, ccol)
+	cImage, free1 := wasmrt.CopyValueToC(image)
+	defer free1()
+	cCol, free2 := wasmrt.CopyValueToC(&col)
+	defer free2()
+	imageColorTint(cImage, cCol)
 	wasmrt.CopyValueToGo(cImage, image)
 }
 

--- a/raylib/rcore_wasm.go
+++ b/raylib/rcore_wasm.go
@@ -2432,6 +2432,7 @@ func imageColorTint(imgStruct wasmrt.Ptr, color wasmrt.Ptr)
 // ImageColorTint - Modify image color: tint
 func ImageColorTint(image *Image, col color.RGBA) {
 	cImage, free := wasmrt.CopyValueToC(image)
+	defer free()
 	ccol, free := wasmrt.CopyValueToC(&col)
 	defer free()
 	imageColorTint(cImage, ccol)


### PR DESCRIPTION
Tested on Digger to create a black mask for a sprite. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of image color tinting in WebAssembly builds.
  * Ensured image and color data are safely transferred and updated during tint operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->